### PR TITLE
Put back upper verison bounds on dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 0a8c06f7622fc4ba067a3edc98661e3e9af93e6d51d94586bd85dbc49ad9eab2
 
 build:
-  number: 1
+  number: 2
   noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
@@ -21,9 +21,9 @@ requirements:
     - python
   run:
     - python
-    - requests >=2.0.0
-    - six >=1.10.0
-    - pyjwt[crypto] >=1.5.3
+    - requests >=2.9.2,<3.0.0
+    - six >=1.10.0,<2.0.0
+    - pyjwt[crypto] >=1.5.3,<2.0.0
 
 test:
   imports:


### PR DESCRIPTION
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.